### PR TITLE
only validate baseType when set

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function errorFactory(name, config, baseType) {
     throw new Error('Error name must be a string');
   } else if (!varValidator.isValid(name, varValidatorOptions)) {
     throw new Error('Invalid error name `' + name + '`');
-  } else if ((arguments.length > 2) && !(baseType && (baseType === Error || baseType.prototype instanceof Error))) {
+  } else if (baseType != null && !(baseType === Error || baseType.prototype instanceof Error)) {
     throw new Error('Invalid base type `' + baseType + '`');
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -334,7 +334,7 @@ describe('Test custom error', function () {
 
     it('should be invalid with invalid error type', function () {
       [
-        undefined, null, false, true, 0,
+        false, true, 0,
         function () {}, function Error() {}, {}, [], /./,
         '', 'Error'
       ].forEach(function (invalidType, index) {


### PR DESCRIPTION
Considering this code.

``` javascript
function create(name, props = {}, inherit) {
    return errorFactory(name, extend({ message: undefined }, props), inherit);
}

let HTTPError = create('HTTPError', { statusCode: 500 });
let Specific create('SpecificHTTPError', { message: 'could not do this or that' });
```

Previously it would validate baseType and throw 'Error: Invalid base type `undefined`' which was not good.

This fixes that issue.
